### PR TITLE
Updated to Angular2-beta.11 and fixed View references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/agGridNg2.d.ts
+++ b/lib/agGridNg2.d.ts
@@ -1,12 +1,13 @@
 // ag-grid-ng2 v4.0.2
+import { GridApi, ColumnApi } from 'ag-grid/main';
 import { ElementRef } from 'angular2/core';
 export declare class AgGridNg2 {
     private elementDef;
     private _initialised;
     private _destroyed;
     private gridOptions;
-    private api;
-    private columnApi;
+    api: GridApi;
+    columnApi: ColumnApi;
     constructor(elementDef: ElementRef);
     ngOnInit(): void;
     ngOnChanges(changes: any): void;

--- a/lib/agGridNg2.js
+++ b/lib/agGridNg2.js
@@ -65,11 +65,9 @@ var AgGridNg2 = (function () {
     AgGridNg2 = __decorate([
         core_1.Component({
             selector: 'ag-grid-ng2',
-            outputs: main_1.ComponentUtil.EVENTS,
-            inputs: main_1.ComponentUtil.ALL_PROPERTIES.concat(['gridOptions'])
-        }),
-        core_1.View({
             template: '',
+            outputs: main_1.ComponentUtil.EVENTS,
+            inputs: main_1.ComponentUtil.ALL_PROPERTIES.concat(['gridOptions']),
             // tell angular we don't want view encapsulation, we don't want a shadow root
             encapsulation: core_1.ViewEncapsulation.None
         }), 

--- a/package.json
+++ b/package.json
@@ -24,22 +24,21 @@
   },
   "homepage": "http://www.ag-grid.com/",
   "devDependencies": {
+    "angular2": "^2.0.0-beta.11",
+    "es6-promise": "^3.1.2",
+    "es6-shim": "^0.35.0",
     "gulp": "3.9.0",
-    "gulp-typescript": "2.10.0",
-    "typescript": "1.7.5",
     "gulp-header": "1.7.0",
+    "gulp-typescript": "2.10.0",
     "merge2": "0.3.6",
-
-    "es6-promise": "^3.0.2",
-    "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.5.15"
+    "typescript": "1.7.5",
+    "zone.js": "^0.6.4"
   },
   "peerDependencies": {
-    "angular2": "2.0.0-beta.8",
+    "angular2": "2.0.0-beta.11",
     "ag-grid": "4.0.x"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/src/agGridNg2.ts
+++ b/src/agGridNg2.ts
@@ -1,14 +1,12 @@
 
 import {Grid, GridOptions, GridApi, ColumnController, ColumnApi, ComponentUtil, Events} from 'ag-grid/main';
-import {Component, View, EventEmitter, ViewEncapsulation, ElementRef} from 'angular2/core';
+import {Component, EventEmitter, ViewEncapsulation, ElementRef} from 'angular2/core';
 
 @Component({
     selector: 'ag-grid-ng2',
-    outputs: ComponentUtil.EVENTS,
-    inputs: ComponentUtil.ALL_PROPERTIES.concat(['gridOptions'])
-})
-@View({
     template: '',
+    outputs: ComponentUtil.EVENTS,
+    inputs: ComponentUtil.ALL_PROPERTIES.concat(['gridOptions']),
     // tell angular we don't want view encapsulation, we don't want a shadow root
     encapsulation: ViewEncapsulation.None
 })


### PR DESCRIPTION
The main change here is the removal of "@View", which doesn't exist anymore in Angular2-beta.11 and causes a runtime exception. I've also updated the project dependencies according to the new Angular2 version.